### PR TITLE
Resolve TLS issues with Generic Provisioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docker-machine*
+kmachine_*
 *.log
 *.iml
 .idea/

--- a/libmachine/provision/configure_kubernetes.go
+++ b/libmachine/provision/configure_kubernetes.go
@@ -22,6 +22,10 @@ func xferCert(p Provisioner, certPath string, targetPath string) error {
 		return err
 	}
 
+    if _, err := p.SSHCommand(fmt.Sprintf("mkdir -p %s", targetPath)); err != nil {
+      return err
+    }
+
     /*
      * TODO: Until we start dynamically generating the configuration file, 
      * these must have a known naming convention on the machine.
@@ -53,132 +57,152 @@ func fixPermissions(p Provisioner, certPath string, targetPath string) error {
 	return nil
 }
 
+func GenerateCertificates(p Provisioner, k8sOptions kubernetes.KubernetesOptions, authOptions auth.AuthOptions) (error) {
+  /* Generate and install certificates. Then kick off kubernetes */
+  driver := p.GetDriver()
+  machine := driver.GetMachineName()
+  bits := 2048  // Based on the initial configuration
+  targetDir := k8sOptions.K8SCertPath
+  ip, err := driver.GetIP()
+  if err != nil {
+    return fmt.Errorf("Error retrieving address: %s", err)
+  }
+
+  err = cert.GenerateCert(
+    []string{ip, "localhost"},
+    k8sOptions.K8SAPICert,
+    k8sOptions.K8SAPIKey,
+    authOptions.CaCertPath,
+    authOptions.CaPrivateKeyPath,
+    kubernetes.GenOrg(machine, "api"),
+    bits)
+
+  if err != nil {
+    return fmt.Errorf("Error generating API cert: %s", err)
+  }
+
+  err = cert.GenerateCert(
+    []string{""},
+    k8sOptions.K8SAdminCert,
+    k8sOptions.K8SAdminKey,
+    authOptions.CaCertPath,
+    authOptions.CaPrivateKeyPath,
+    kubernetes.GenOrg(machine, "admin"),
+    bits)
+
+  if err != nil {
+    return fmt.Errorf("Error generating Admin cert: %s", err)
+  }
+
+  err = cert.GenerateCert(
+    []string{},
+    k8sOptions.K8SProxyCert,
+    k8sOptions.K8SProxyKey,
+    authOptions.CaCertPath,
+    authOptions.CaPrivateKeyPath,
+    kubernetes.GenOrg(machine, "proxy"),
+    bits)
+
+  if err != nil {
+    return fmt.Errorf("Error generating proxy cert: %s", err)
+  }
+
+  /* Copy certs into place */
+  log.Info("Copying certs to the remote system...")
+
+  /* Kick off the kubernetes run */
+  if _, err := p.SSHCommand(fmt.Sprintf("mkdir -p %s", targetDir)); err != nil {
+    return err
+  }
+
+  if _, err := p.SSHCommand(fmt.Sprintf("printf '%q,%s,%d' |sudo tee %s", k8sOptions.K8SToken, "kuser",0,path.Join(targetDir, "tokenfile.txt"))); err != nil {
+    return err
+  }
+
+  if err := xferCert(p, k8sOptions.K8SAPIKey, targetDir + "/apiserver"); err != nil {
+    return err
+  }
+
+  if err := fixPermissions(p, k8sOptions.K8SAPIKey, targetDir + "/apiserver"); err != nil {
+    return err
+  }
+
+  if err := xferCert(p, k8sOptions.K8SAPICert, targetDir + "/apiserver"); err != nil {
+    return err
+  }
+
+  if err := xferCert(p, k8sOptions.K8SProxyCert, targetDir + "/proxyserver"); err != nil {
+    return err
+  }
+
+  if err := xferCert(p, k8sOptions.K8SProxyKey, targetDir + "/proxyserver"); err != nil {
+    return err
+  }
+
+  if err := fixPermissions(p, k8sOptions.K8SProxyKey, targetDir + "/proxyserver"); err != nil {
+    return err
+  }
+
+  if err := xferCert(p, k8sOptions.K8SAdminCert, targetDir + "/kubelet"); err != nil {
+    return err
+  }
+
+  if err := xferCert(p, k8sOptions.K8SAdminKey, targetDir + "/kubelet"); err != nil {
+    return err
+  }
+
+  if err := fixPermissions(p, k8sOptions.K8SAdminKey, targetDir + "/kubelet"); err != nil {
+    return err
+  }
+
+  /* Copy the CA cert to a known location */
+  caCertContents, err := ioutil.ReadFile(authOptions.CaCertPath)
+  if err != nil {
+    return err
+  }
+
+  if _, err := p.SSHCommand(fmt.Sprintf("printf '%%s' '%s' | sudo tee %s/ca.pem", caCertContents, targetDir)); err != nil {
+    return err
+  }
+
+  return nil
+}
+
 func configureKubernetes(p Provisioner, k8sOptions *kubernetes.KubernetesOptions, authOptions auth.AuthOptions) (error) {
     log.Info("Configuring kubernetes...")
 
-    if _, err := p.SSHCommand("sudo /bin/sh /usr/local/etc/init.d/kubelet stop"); err != nil {
-        log.Info("Errored while attempting to stop the kubelet: %s", err)
-    }
+  if _, err := p.SSHCommand("sudo /bin/sh /usr/local/etc/init.d/kubelet stop"); err != nil {
+      log.Info("Errored while attempting to stop the kubelet: %s", err)
+  }
 
-    /* Generate and install certificates. Then kick off kubernetes */
+  if err := GenerateCertificates(p, *k8sOptions, authOptions); err != nil {
+    return err
+  }
+
+  /* Generate and install certificates. Then kick off kubernetes */
 	driver := p.GetDriver()
 	machine := driver.GetMachineName()
-	bits := 2048	// Based on the initial configuration
-	ip, err := driver.GetIP()
-	if err != nil {
-		return fmt.Errorf("Error retrieving address: %s", err)
-	}
+  targetDir := k8sOptions.K8SCertPath
 
-	err = cert.GenerateCert(
-		[]string{ip, "localhost"},
-		k8sOptions.K8SAPICert,
-		k8sOptions.K8SAPIKey,
-		authOptions.CaCertPath,
-		authOptions.CaPrivateKeyPath,
-		kubernetes.GenOrg(machine, "api"),
-		bits)
+  /* Generate and copy a new YAML file to the target */
+  configFile, err := Generatek8sManifest(machine, targetDir)
+  if err != nil {
+      return err
+  }
 
-	if err != nil {
-		return fmt.Errorf("Error generating API cert: %s", err)
-	}
+  kubeletConfig, err := GenerateKubeletConfig(machine, targetDir)
+  if err != nil {
+      return err
+  }
 
-	err = cert.GenerateCert(
-		[]string{""},
-		k8sOptions.K8SAdminCert,
-		k8sOptions.K8SAdminKey,
-		authOptions.CaCertPath,
-		authOptions.CaPrivateKeyPath,
-		kubernetes.GenOrg(machine, "admin"),
-		bits)
+  /* TOOD: The target manifest directory should be a parameter throughout here */
+  if _, err := p.SSHCommand(fmt.Sprintf("printf '%%s' '%s' | sudo tee %s", kubeletConfig, "/etc/kubernetes/kubelet.kubeconfig")); err != nil {
+      return err
+  }
 
-	if err != nil {
-		return fmt.Errorf("Error generating Admin cert: %s", err)
-	}
-
-	err = cert.GenerateCert(
-		[]string{},
-		k8sOptions.K8SProxyCert,
-		k8sOptions.K8SProxyKey,
-		authOptions.CaCertPath,
-		authOptions.CaPrivateKeyPath,
-		kubernetes.GenOrg(machine, "proxy"),
-		bits)
-
-	if err != nil {
-		return fmt.Errorf("Error generating proxy cert: %s", err)
-	}
-
-	/* Copy certs into place */
-	log.Info("Copying certs to the remote system...")
-
-	/* CAB: This should probably be an option */
-	targetDir := k8sOptions.K8SCertPath
-
-    /* Kick off the kubernetes run */
-    if _, err := p.SSHCommand(fmt.Sprintf("printf '%q,%s,%d' |sudo tee %s", k8sOptions.K8SToken, "kuser",0,path.Join(targetDir, "tokenfile.txt"))); err != nil {
-        return err
-    }
-
-	if err := xferCert(p, k8sOptions.K8SAPIKey, targetDir + "/apiserver"); err != nil {
-		return err
-	}
-
-	if err := fixPermissions(p, k8sOptions.K8SAPIKey, targetDir + "/apiserver"); err != nil {
-		return err
-	}
-
-	if err := xferCert(p, k8sOptions.K8SAPICert, targetDir + "/apiserver"); err != nil {
-		return err
-	}
-
-	if err := xferCert(p, k8sOptions.K8SProxyCert, targetDir + "/proxyserver"); err != nil {
-		return err
-	}
-
-	if err := xferCert(p, k8sOptions.K8SProxyKey, targetDir + "/proxyserver"); err != nil {
-		return err
-	}
-
-	if err := fixPermissions(p, k8sOptions.K8SProxyKey, targetDir + "/proxyserver"); err != nil {
-		return err
-	}
-
-	if err := xferCert(p, k8sOptions.K8SAdminCert, targetDir + "/kubelet"); err != nil {
-		return err
-	}
-
-	if err := xferCert(p, k8sOptions.K8SAdminKey, targetDir + "/kubelet"); err != nil {
-		return err
-	}
-
-	if err := fixPermissions(p, k8sOptions.K8SAdminKey, targetDir + "/kubelet"); err != nil {
-		return err
-	}
-
-	/* Copy the CA cert to a known location */
-	if _, err := p.SSHCommand(fmt.Sprintf("sudo cp /home/docker/.docker/ca.pem %s/ca.pem", targetDir)); err != nil {
-		return err
-	}
-
-    /* Generate and copy a new YAML file to the target */
-    configFile, err := Generatek8sManifest(machine, targetDir)
-    if err != nil {
-        return err
-    }
-
-    kubeletConfig, err := GenerateKubeletConfig(machine, targetDir)
-    if err != nil {
-        return err
-    }
-
-    /* TOOD: The target manifest directory should be a parameter throughout here */
-    if _, err := p.SSHCommand(fmt.Sprintf("printf '%%s' '%s' | sudo tee %s", kubeletConfig, "/etc/kubernetes/kubelet.kubeconfig")); err != nil {
-        return err
-    }
-
-    if _, err := p.SSHCommand(fmt.Sprintf("printf '%%s' '%s' | sudo tee %s", configFile, "/etc/kubernetes/manifests/kubernetes.yaml")); err != nil {
-        return err
-    }
+  if _, err := p.SSHCommand(fmt.Sprintf("printf '%%s' '%s' | sudo tee %s", configFile, "/etc/kubernetes/manifests/kubernetes.yaml")); err != nil {
+      return err
+  }
 
 	/* Lastly, start the kubelet */
     if _, err := p.SSHCommand("sudo /bin/sh /usr/local/etc/init.d/kubelet start"); err != nil {

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -148,13 +148,13 @@ func (provisioner *UbuntuProvisioner) Provision(k8sOptions kubernetes.Kubernetes
 		return err
 	}
 
-	if err := installk8sGeneric(provisioner); err != nil {
-		return err
-	}
-
 	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
 
 	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	if err := installk8sGeneric(provisioner); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The TLS support added yesterday only supported the boot2docker images, and did not get picked up by Generic provisioner for most of the other cloud providers.  This putback corrects the oversight, and does work with at least digital ocean.