### PR TITLE
Forced the creation of the /etc/kubernetes directory if it doesn't exist

### DIFF
--- a/libmachine/provision/configure_kubernetes.go
+++ b/libmachine/provision/configure_kubernetes.go
@@ -196,6 +196,11 @@ func configureKubernetes(p Provisioner, k8sOptions *kubernetes.KubernetesOptions
   }
 
   /* TOOD: The target manifest directory should be a parameter throughout here */
+  /* Ensure that the kubernetes configuration directory exists */
+  if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p /etc/kubernetes/manifests")); err != nil {
+      return err
+  }
+
   if _, err := p.SSHCommand(fmt.Sprintf("printf '%%s' '%s' | sudo tee %s", kubeletConfig, "/etc/kubernetes/kubelet.kubeconfig")); err != nil {
       return err
   }


### PR DESCRIPTION
An edge case was noticed where there's the possibility that the kubelet maybe installed, but not running.  In this case, the initial kubernetes directories of /var/run/kubernetes and /etc/kubernetes may not have been created.  While I make sure to create /var/run/kubernetes for exporting the certs in case the kubelet is running in a docker container, /etc/kubernetes was left out.  This pull request will resolve this case before pushing out the manifest.yaml, and kubelet.kubeconfig files.