### PR TITLE
Modified mkdir to be prefixed with sudo

### DIFF
--- a/libmachine/provision/configure_kubernetes.go
+++ b/libmachine/provision/configure_kubernetes.go
@@ -22,7 +22,7 @@ func xferCert(p Provisioner, certPath string, targetPath string) error {
 		return err
 	}
 
-    if _, err := p.SSHCommand(fmt.Sprintf("mkdir -p %s", targetPath)); err != nil {
+    if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s", targetPath)); err != nil {
       return err
     }
 
@@ -111,7 +111,7 @@ func GenerateCertificates(p Provisioner, k8sOptions kubernetes.KubernetesOptions
   log.Info("Copying certs to the remote system...")
 
   /* Kick off the kubernetes run */
-  if _, err := p.SSHCommand(fmt.Sprintf("mkdir -p %s", targetDir)); err != nil {
+  if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s", targetDir)); err != nil {
     return err
   }
 


### PR DESCRIPTION
Resolves issue #19 as digitalocean's ssh keys allow for root access directly while aws relies on sudo for the more privileged operations.