### PR TITLE
hyperkube upgrade to v1.1.2 and binary rename to kmachine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ else ifeq ($(USE_CONTAINER),)
 	include mk/main.mk
 else
 # Otherwise, with docker, swallow all targets and forward into a container
-DOCKER_IMAGE_NAME := "docker-machine-build"
-DOCKER_CONTAINER_NAME := "docker-machine-build-container"
+DOCKER_IMAGE_NAME := "kmachine-build"
+DOCKER_CONTAINER_NAME := "kmachine-build-container"
 
 .ignore:
 	@

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -181,7 +181,7 @@ func (d *Driver) Create() error {
 	command = []string{
 		"Set-VMDvdDrive",
 		"-VMName", d.MachineName,
-		"-Path", fmt.Sprintf("'%s'", d.ResolveStorePath("boot2docker.iso"))}
+		"-Path", fmt.Sprintf("'%s'", d.ResolveStorePath("boot2k8s.iso"))}
 	_, err = execute(command)
 	if err != nil {
 		return err

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	isoFilename                = "boot2docker.iso"
+	isoFilename                = "boot2k8s.iso"
 	defaultCPU                 = 1
 	defaultMemory              = 1024
 	defaultBoot2DockerURL      = ""
@@ -355,7 +355,7 @@ func (d *Driver) Create() error {
 		"--port", "0",
 		"--device", "0",
 		"--type", "dvddrive",
-		"--medium", d.ResolveStorePath("boot2docker.iso")); err != nil {
+		"--medium", d.ResolveStorePath("boot2k8s.iso")); err != nil {
 		return err
 	}
 

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -29,7 +29,7 @@ import (
 const (
 	B2DUser        = "docker"
 	B2DPass        = "tcuser"
-	isoFilename    = "boot2docker.iso"
+	isoFilename    = "boot2k8s.iso"
 	isoConfigDrive = "configdrive.iso"
 )
 

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	isoFilename = "boot2docker.iso"
+	isoFilename = "boot2k8s.iso"
 	B2DISOName  = isoFilename
 	B2DUser     = "docker"
 	B2DPass     = "tcuser"

--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -85,7 +85,7 @@ func (e ErrPluginBinaryNotFound) Error() string {
 }
 
 func NewLocalBinaryPlugin(driverName string) (*LocalBinaryPlugin, error) {
-	binaryPath, err := exec.LookPath(fmt.Sprintf("docker-machine-driver-%s", driverName))
+	binaryPath, err := exec.LookPath(fmt.Sprintf("kmachine-driver-%s", driverName))
 	if err != nil {
 		return nil, ErrPluginBinaryNotFound{driverName}
 	}

--- a/libmachine/provision/configure_kubernetes.go
+++ b/libmachine/provision/configure_kubernetes.go
@@ -328,14 +328,14 @@ spec:
         - "--listen-peer-urls=http://127.0.0.1:2380"
         - "--name=etcd"
     - name: "controller-manager"
-      image: "gcr.io/google_containers/hyperkube:v1.0.3"
+      image: "gcr.io/google_containers/hyperkube:v1.1.2"
       args:
         - "/hyperkube"
         - "controller-manager"
         - "--master=http://127.0.0.1:8080"
         - "--v=2"
     - name: "apiserver"
-      image: "gcr.io/google_containers/hyperkube:v1.0.3"
+      image: "gcr.io/google_containers/hyperkube:v1.1.2"
       volumeMounts:
         - name: "certs"
           mountPath: "{{.CertDir}}"
@@ -359,7 +359,7 @@ spec:
         - "--tls-private-key-file={{.CertDir}}/apiserver/key.pem"
         - "--v=2"
     - name: "proxy"
-      image: "gcr.io/google_containers/hyperkube:v1.0.3"
+      image: "gcr.io/google_containers/hyperkube:v1.1.2"
       securityContext:
         privileged: true
       args:
@@ -368,7 +368,7 @@ spec:
         - "--master=http://127.0.0.1:8080"
         - "--v=2"
     - name: "scheduler"
-      image: "gcr.io/google_containers/hyperkube:v1.0.3"
+      image: "gcr.io/google_containers/hyperkube:v1.1.2"
       args:
         - "/hyperkube"
         - "scheduler"

--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -131,7 +131,7 @@ users:
     },
     {
       "name": "controller-manager",
-      "image": "gcr.io/google_containers/hyperkube:v1.0.3",
+      "image": "gcr.io/google_containers/hyperkube:v1.1.2",
       "args": [
               "/hyperkube",
               "controller-manager",
@@ -141,7 +141,7 @@ users:
     },
     {
       "name": "apiserver",
-      "image": "gcr.io/google_containers/hyperkube:v1.0.3",
+      "image": "gcr.io/google_containers/hyperkube:v1.1.2",
       "volumeMounts": [ 
           {"name": "certs",
           "mountPath": "{{.CertDir}}",
@@ -168,7 +168,7 @@ users:
     },
     {
       "name": "proxy",
-      "image": "gcr.io/google_containers/hyperkube:v1.0.3",
+      "image": "gcr.io/google_containers/hyperkube:v1.1.2",
       "securityContext": {
         "privileged": true
         },
@@ -181,7 +181,7 @@ users:
     },
     {
       "name": "scheduler",
-      "image": "gcr.io/google_containers/hyperkube:v1.0.3",
+      "image": "gcr.io/google_containers/hyperkube:v1.1.2",
       "args": [
               "/hyperkube",
               "scheduler",

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -136,6 +136,10 @@ func (provisioner *UbuntuProvisioner) Provision(k8sOptions kubernetes.Kubernetes
 		}
 	}
 
+	if err := upgradeSystem(provisioner); err != nil {
+		return err
+	}
+
 	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
 		return err
 	}

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -14,7 +14,7 @@ endef
 # XXX building with -a fails in debug (with -N -l) ????
 
 # Independent targets for every bin
-$(PREFIX)/bin/docker-%: ./cmd/%.go $(shell find . -type f -name '*.go')
+$(PREFIX)/bin/k%: ./cmd/%.go $(shell find . -type f -name '*.go')
 	$(GO) build -o $@$(call extension,$(GOOS)) $(VERBOSE_GO) -tags "$(BUILDTAGS)" -ldflags "$(GO_LDFLAGS)" $(GO_GCFLAGS) $<
 
 # Cross-compilation targets
@@ -22,10 +22,10 @@ build-x-%: ./cmd/%.go $(shell find . -type f -name '*.go')
 	$(foreach GOARCH,$(TARGET_ARCH),$(foreach GOOS,$(TARGET_OS),$(call gocross,$(GOOS),$(GOARCH),$<)))
 
 # Build just machine
-build-machine: $(PREFIX)/bin/docker-machine
+build-machine: $(PREFIX)/bin/kmachine
 
 # Build all plugins
-build-plugins: $(patsubst ./cmd/%.go,$(PREFIX)/bin/docker-%,$(filter-out %_test.go, $(wildcard ./cmd/machine-driver-*.go)))
+build-plugins: $(patsubst ./cmd/%.go,$(PREFIX)/bin/k%,$(filter-out %_test.go, $(wildcard ./cmd/machine-driver-*.go)))
 
 # Overall cross-build
 build-x: $(patsubst ./cmd/%.go,build-x-%,$(filter-out %_test.go, $(wildcard ./cmd/*.go)))

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -57,7 +57,7 @@ plugins: build-plugins
 cross: build-x
 
 install:
-	cp $(PREFIX)/bin/docker-machine $(PREFIX)/bin/docker-machine-driver* /usr/local/bin
+	cp $(PREFIX)/bin/kmachine $(PREFIX)/bin/kmachine-driver* /usr/local/bin
 
 clean: coverage-clean build-clean
 test: dco fmt test-short vet


### PR DESCRIPTION
Also includes some fixes for the boot2k8s.iso rename with some drivers, and a fix to the ubuntu provisioner to ensure that the required kernel image can install cleanly.